### PR TITLE
Move single_pass functions into keyword arguments.

### DIFF
--- a/ristretto/dmd.py
+++ b/ristretto/dmd.py
@@ -188,7 +188,7 @@ def rdmd(A, dt=1, k=None, p=10, l=None, q=2, sdist='uniform', single_pass=False,
 
     q : int, optional
         Number of subspace iterations to perform. Only relevant if
-        singel_pass == False
+        single_pass == False
 
     sdist : str `{'uniform', 'normal'}`
         Specify the distribution of the sensing matrix `S`.

--- a/ristretto/interp_decomp.py
+++ b/ristretto/interp_decomp.py
@@ -262,7 +262,7 @@ def rinterp_decomp(A, k=None, mode='column', p=10, q=1, sdist='normal',
 
 def rinterp_decomp_qb(A, k=None, mode='column', p=10, q=1, sdist='normal',
                       index_set=False, random_state=None):
-    """Randomized interpolative decomposition (rID).
+    r"""Randomized interpolative decomposition (rID).
 
     Algorithm for computing the approximate low-rank ID
     decomposition of a rectangular `(m, n)` matrix `A`, with target rank `k << min{m, n}`.

--- a/ristretto/pca.py
+++ b/ristretto/pca.py
@@ -15,7 +15,7 @@ from .qb import rqb
 
 def spca(X, n_components=None, alpha=0.1, beta=0.01, max_iter=500, tol=1e-5,
         verbose=True):
-    """Sparse Principal Component Analysis (SPCA).
+    r"""Sparse Principal Component Analysis (SPCA).
 
     Given a mean centered rectangular matrix `A` with shape `(m, n)`, SPCA
     computes a set of sparse components that can optimally reconstruct the
@@ -139,7 +139,7 @@ def spca(X, n_components=None, alpha=0.1, beta=0.01, max_iter=500, tol=1e-5,
 
 def robspca(X, n_components, alpha=0.1, beta=0.1, gamma=0.1, max_iter=1000,
             tol=1e-5, verbose=True):
-    """Robust Sparse Principal Component Analysis (Robust SPCA).
+    r"""Robust Sparse Principal Component Analysis (Robust SPCA).
 
     Given a mean centered rectangular matrix `A` with shape `(m, n)`, SPCA
     computes a set of sparse components that can optimally reconstruct the
@@ -285,7 +285,7 @@ def robspca(X, n_components, alpha=0.1, beta=0.1, gamma=0.1, max_iter=1000,
 
 def rspca(X, n_components, alpha=0.1, beta=0.1, max_iter=1000, tol=1e-5,
           verbose=0, p=20, q=2, random_state=None):
-    """Randomized Sparse Principal Component Analysis (rSPCA).
+    r"""Randomized Sparse Principal Component Analysis (rSPCA).
 
     Given a mean centered rectangular matrix `A` with shape `(m, n)`, SPCA
     computes a set of sparse components that can optimally reconstruct the

--- a/ristretto/qb.py
+++ b/ristretto/qb.py
@@ -41,7 +41,8 @@ def rqb(A, k=None, p=10, l=None, q=1, sdist='normal', single_pass=False,
         single_pass == True.
 
     q : integer, default: `q=1`.
-        Parameter to control number of power (subspace) iterations.
+        Parameter to control number of power (subspace) iterations. Only
+        relevant if single_pass == False.
 
     sdist : str `{'uniform', 'normal'}`, default: `sdist='uniform'`.
         'uniform' : Random test matrix with uniform distributed elements.
@@ -93,8 +94,8 @@ def rqb(A, k=None, p=10, l=None, q=1, sdist='normal', single_pass=False,
         del Omega
 
         #Orthogonalize Y using economic QR decomposition: Y=QR
-        Q, _ = linalg.qr(Y, mode='economic', check_finite=False, overwrite_a=True )
-        U, T = linalg.qr(Psi.dot(Q), mode='economic', check_finite=False, overwrite_a=False )
+        Q, _ = linalg.qr(Y, mode='economic', check_finite=False, overwrite_a=True)
+        U, T = linalg.qr(Psi.dot(Q), mode='economic', check_finite=False, overwrite_a=False)
 
         # Form a smaller matrix
         B = linalg.solve(T, conjugate_transpose(U).dot(W), check_finite=False,

--- a/ristretto/qb.py
+++ b/ristretto/qb.py
@@ -12,7 +12,8 @@ from .sketch import sketch, single_pass_sketch
 from .utils import conjugate_transpose
 
 
-def rqb(A, k=None, p=10, q=1, sdist='normal', random_state=None):
+def rqb(A, k=None, p=10, l=None, q=1, sdist='normal', single_pass=False,
+        random_state=None):
     """Randomized QB Decomposition.
 
     Randomized algorithm for computing the approximate low-rank QB
@@ -33,7 +34,11 @@ def rqb(A, k=None, p=10, q=1, sdist='normal', random_state=None):
         Target rank.
 
     p : integer, default: `p=10`.
-        Parameter to control oversampling.
+        Parameter to control oversampling of column space.
+
+    l : integer, default: `l=2*p`.
+        Parameter to control oversampling of row space. Only relevant if
+        single_pass == True.
 
     q : integer, default: `q=1`.
         Parameter to control number of power (subspace) iterations.
@@ -42,6 +47,9 @@ def rqb(A, k=None, p=10, q=1, sdist='normal', random_state=None):
         'uniform' : Random test matrix with uniform distributed elements.
 
         'normal' : Random test matrix with normal distributed elements.
+
+    single_pass : bool
+        If single_pass == True, perfom single pass of algorithm.
 
     random_state : integer, RandomState instance or None, optional (default ``None``)
         If integer, random_state is the seed used by the random number generator;
@@ -72,92 +80,32 @@ def rqb(A, k=None, p=10, q=1, sdist='normal', random_state=None):
     and GPU architectures" (2015).
     (available at `arXiv <http://arxiv.org/abs/1502.05366>`_).
     """
-    # get random sketch
-    Q = sketch(A, output_rank=k, n_oversample=p, n_iter=q, distribution=sdist,
-               axis=1, check_finite=True, random_state=random_state)
+    if single_pass:
+        # Form a smaller matrix
+        Omega, Psi = single_pass_sketch(
+            A, output_rank=k, column_oversample=p, row_oversample=l,
+            distribution=sdist, check_finite=True, random_state=random_state)
 
-    #Project the data matrix a into a lower dimensional subspace
-    B = conjugate_transpose(Q).dot(A)
+        #Build sample matrix Y = A * Omega and W = Psi * A
+        #Note: Y should approximate the column space and W the row space of A
+        Y = A.dot(Omega)
+        W = Psi.dot(A)
+        del Omega
 
-    return Q, B
+        #Orthogonalize Y using economic QR decomposition: Y=QR
+        Q, _ = linalg.qr(Y, mode='economic', check_finite=False, overwrite_a=True )
+        U, T = linalg.qr(Psi.dot(Q), mode='economic', check_finite=False, overwrite_a=False )
 
+        # Form a smaller matrix
+        B = linalg.solve(T, conjugate_transpose(U).dot(W), check_finite=False,
+                         overwrite_a=True, overwrite_b=True)
 
-def rqb_single(A, k=None, p=10, l=None, q=1, sdist='normal', random_state=None):
-    """Randomized QB Decomposition.
+    else:
+        # get random sketch
+        Q = sketch(A, output_rank=k, n_oversample=p, n_iter=q, distribution=sdist,
+                   axis=1, check_finite=True, random_state=random_state)
 
-    Randomized algorithm for computing the approximate low-rank QB
-    decomposition of a rectangular `(m, n)` matrix `A`, with target rank `k << min{m, n}`.
-    The input matrix is factored as `A = Q * B`.
-
-    The quality of the approximation can be controlled via the oversampling
-    parameter `p` and the parameter `q` which specifies the number of
-    subspace iterations.
-
-
-    Parameters
-    ----------
-    A : array_like, shape `(m, n)`.
-        Real nonnegative input matrix.
-
-    k : integer, `k << min{m,n}`.
-        Target rank.
-
-    p : integer, default: `p=10`.
-        Parameter to control oversampling.
-
-    q : integer, default: `q=1`.
-        Parameter to control number of power (subspace) iterations.
-
-    sdist : str `{'uniform', 'normal'}`, default: `sdist='uniform'`.
-        'uniform' : Random test matrix with uniform distributed elements.
-
-        'normal' : Random test matrix with normal distributed elements.
-
-    random_state : integer, RandomState instance or None, optional (default ``None``)
-        If integer, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used by np.random.
-
-    Returns
-    -------
-    Q:  array_like, shape `(m, k+p)`.
-        Orthonormal basis matrix.
-
-    B : array_like, shape `(k+p, n)`.
-        Smaller matrix.
-
-
-    References
-    ----------
-    N. Halko, P. Martinsson, and J. Tropp.
-    "Finding structure with randomness: probabilistic
-    algorithms for constructing approximate matrix
-    decompositions" (2009).
-    (available at `arXiv <http://arxiv.org/abs/0909.4061>`_).
-
-    S. Voronin and P.Martinsson.
-    "RSVDPACK: Subroutines for computing partial singular value
-    decompositions via randomized sampling on single core, multi core,
-    and GPU architectures" (2015).
-    (available at `arXiv <http://arxiv.org/abs/1502.05366>`_).
-    """
-    # Form a smaller matrix
-    Omega, Psi = single_pass_sketch(
-        A, output_rank=k, column_oversample=p, row_oversample=l,
-        distribution=sdist, check_finite=True, random_state=random_state)
-
-    #Build sample matrix Y = A * Omega and W = Psi * A
-    #Note: Y should approximate the column space and W the row space of A
-    Y = A.dot(Omega)
-    W = Psi.dot(A)
-    del Omega
-
-    #Orthogonalize Y using economic QR decomposition: Y=QR
-    Q, _ = linalg.qr(Y, mode='economic', check_finite=False, overwrite_a=True )
-    U, T = linalg.qr(Psi.dot(Q), mode='economic', check_finite=False, overwrite_a=False )
-
-    # Form a smaller matrix
-    B = linalg.solve(T, conjugate_transpose(U).dot(W), check_finite=False,
-                     overwrite_a=True, overwrite_b=True)
+        #Project the data matrix a into a lower dimensional subspace
+        B = conjugate_transpose(Q).dot(A)
 
     return Q, B

--- a/ristretto/svd.py
+++ b/ristretto/svd.py
@@ -330,7 +330,8 @@ def rsvd(A, k=None, p=10, l=None, q=1, sdist='uniform', single_pass=False,
         single_pass == True.
 
     q : integer, default: `q=1`.
-        Parameter to control number of power (subspace) iterations.
+        Parameter to control number of power (subspace) iterations. Only
+        relevant if single_pass == False.
 
     sdist : str `{'uniform', 'normal'}`, default: `sdist='uniform'`.
         'uniform' : Random test matrix with uniform distributed elements.

--- a/ristretto/tests/test_dmd.py
+++ b/ristretto/tests/test_dmd.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from ristretto.dmd import dmd
 from ristretto.dmd import rdmd
-from ristretto.dmd import rdmd_single
 
 atol_float32 = 1e-4
 atol_float64 = 1e-8
@@ -68,11 +67,7 @@ def test_rdmd():
     assert np.allclose(A, Atilde, atol_float64)
 
 
-
-# =============================================================================
-# rdmd_single function
-# =============================================================================
-def test_rdmd_single():
+def test_rdmd_single_pass():
     # Define time and space discretizations
     x=np.linspace( -10, 10, 100)
     t=np.linspace(0, 8*np.pi , 60)
@@ -84,12 +79,12 @@ def test_rdmd_single():
     F2 = ( (1./np.cosh(X)) * np.tanh(X)) *(2.*np.exp(1j*2.8*T))
     A = np.array((F1+F2).T, order='C')
 
-    Fmodes, b, V, omega = rdmd_single(A, k=2, p=10, l=20, sdist='uniform',
-                                      return_amplitudes=True, return_vandermonde=True)
+    Fmodes, b, V, omega = rdmd(A, k=2, p=10, l=20, sdist='uniform', single_pass=True,
+                               return_amplitudes=True, return_vandermonde=True)
     Atilde = Fmodes.dot( np.dot(np.diag(b), V))
     assert np.allclose(A, Atilde, atol_float64)
 
-    Fmodes, b, V, omega = rdmd_single(A, k=2, p=10, l=20, sdist='orthogonal',
-                                      return_amplitudes=True, return_vandermonde=True)
+    Fmodes, b, V, omega = rdmd(A, k=2, p=10, l=20, sdist='orthogonal', single_pass=True,
+                               return_amplitudes=True, return_vandermonde=True)
     Atilde = Fmodes.dot( np.dot(np.diag(b), V))
     assert np.allclose(A, Atilde, atol_float64)

--- a/ristretto/tests/test_svd.py
+++ b/ristretto/tests/test_svd.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from ristretto.svd import rsvd
-from ristretto.svd import rsvd_single
 
 atol_float32 = 1e-4
 atol_float64 = 1e-8
@@ -58,14 +57,11 @@ def test_rsvd_fliped_complex128():
     assert percent_error < atol_float64
 
 
-# =============================================================================
-# rsvd_single function
-# =============================================================================
 def test_rsvd_single_float64():
     m, k = 100, 10
     A = np.array(np.random.randn(m, k), np.float64)
     A = A.dot( A.T )
-    U, s, Vt = rsvd_single(A, k=k, p=5)
+    U, s, Vt = rsvd(A, k=k, p=5, single_pass=True)
     Ak = U.dot(np.diag(s).dot(Vt))
     percent_error = 100 * np.linalg.norm(A - Ak) / np.linalg.norm(A)
 
@@ -77,7 +73,7 @@ def test_rsvd_single_complex128():
     A = np.array(np.random.randn(m, k), np.float64) + 1j * \
             np.array(np.random.randn(m, k), np.float64)
     A = A.dot(A.conj().T)
-    U, s, Vh = rsvd_single(A, k=k, p=5)
+    U, s, Vh = rsvd(A, k=k, p=5, single_pass=True)
     Ak = U.dot(np.diag(s).dot(Vh))
     percent_error = 100 * np.linalg.norm(A - Ak) / np.linalg.norm(A)
 
@@ -87,6 +83,6 @@ def test_rsvd_single_orthogonal_complex128():
     A = np.array(np.random.randn(m, k), np.float64) + 1j * \
             np.array(np.random.randn(m, k), np.float64)
     A = A.dot(A.conj().T)
-    U, s, Vh = rsvd_single(A, k=k, p=5, sdist='orthogonal')
+    U, s, Vh = rsvd(A, k=k, p=5, sdist='orthogonal', single_pass=True)
     Ak = U.dot(np.diag(s).dot(Vh))
     percent_error = 100 * np.linalg.norm(A - Ak) / np.linalg.norm(A)


### PR DESCRIPTION
Moves functionality for single pass algorithms into the general
functions by including the keyword argument ``single_pass`` into such
functions. ie

``rqb_single``       -> ``rqb(A, ..., single_pass=True)``
``rdmd_single`` -> ``rdmd(A, ..., single_pass=True)``
``rsvd_single``   -> ``rsvd(A, ..., single_pass=True)``