### PR TITLE
Added testing dependency `nose`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,7 @@ the release::
 * scipy
 * Cython
 * scikit-learn
+* nose
 
 After successfully installing the ristretto library, the unit tests can be run by::
 


### PR DESCRIPTION
Seems like it's not a real dependency of the library, but the next command in the README fails without `nose`.